### PR TITLE
component-release.yml: publish a versioned release of an infra component

### DIFF
--- a/.github/workflows/component-release.yml
+++ b/.github/workflows/component-release.yml
@@ -22,8 +22,8 @@ jobs:
         env:
           PUBLISH_REMOTE: origin
         run: |
-          git config user.name  "$(git log -1 --format=%cn)"
-          git config user.email "$(git log -1 --format=%ce)"
+          git config user.name  "$(git log -1 --format=%cn "$GITHUB_REF")"
+          git config user.email "$(git log -1 --format=%ce "$GITHUB_REF")"
           parents=( $(git log -1 --format=%P "$GITHUB_REF") )
           if [[ ${#parents[*]} -gt 1 ]]; then
 

--- a/.github/workflows/component-release.yml
+++ b/.github/workflows/component-release.yml
@@ -1,0 +1,51 @@
+name: Publish a versioned release of an infrastructure component
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+
+  publish-component:
+
+
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: publish
+        shell: bash
+        env:
+          PUBLISH_REMOTE: origin
+        run: |
+          git config user.name  "$(git log -1 --format=%cn)"
+          git config user.email "$(git log -1 --format=%ce)"
+          parents=( $(git log -1 --format=%P "$GITHUB_REF") )
+          if [[ ${#parents[*]} -gt 1 ]]; then
+
+            # NOTE: This workflow assumes all merges will have exactly two parents.
+            # Octopus merges break this assumption and should be avoided.
+            merge_head_rev=${parents[1]}
+            release_refs=( $(git show-ref | grep "$merge_head_rev" | awk '{print $2}' | grep "^refs/remotes/$PUBLISH_REMOTE/releases/" || true) )
+
+            for ref in "${release_refs[@]}"; do
+              branch=${ref#refs/remotes/$PUBLISH_REMOTE/}
+              component=$(dirname "${branch#releases/}")
+              version=$(basename "${branch#releases/}")
+              printf 'info: publishing component: %s %s\n' "$component" "$version"
+              "$GITHUB_WORKSPACE"/.sh/publish-component.sh "$component" "$version"
+              git push --delete "$PUBLISH_REMOTE" "$ref"
+            done
+
+            printf 'info: done publishing components.\n'
+
+          else
+
+            printf 'warn: HEAD is not a merge; skipping release\n'
+            exit 0
+
+          fi

--- a/.github/workflows/component-release.yml
+++ b/.github/workflows/component-release.yml
@@ -38,7 +38,7 @@ jobs:
               version=$(basename "${branch#releases/}")
               printf 'info: publishing component: %s %s\n' "$component" "$version"
               "$GITHUB_WORKSPACE"/.sh/publish-component.sh "$component" "$version"
-              git push --delete "$PUBLISH_REMOTE" "$ref"
+              git push --delete "$PUBLISH_REMOTE" "$branch"
             done
 
             printf 'info: done publishing components.\n'

--- a/.sh/publish-component.sh
+++ b/.sh/publish-component.sh
@@ -13,7 +13,7 @@ COMPONENT_VERSION=$2
 COMPONENT_PATH=
 
 # NOTE: git-subtree-split will fail on absolute paths, so COMPONENT_PATH must
-# be relativw ro PROJECT_ROOT
+# be relative ro PROJECT_ROOT
 test ! -d "$PROJECT_ROOT/$COMPONENT_NAME"             || COMPONENT_PATH=$COMPONENT_NAME
 test ! -d "$PROJECT_ROOT/deployments/$COMPONENT_NAME" || COMPONENT_PATH=deployments/$COMPONENT_NAME
 test "$PUBLISH_REMOTE"                                || PUBLISH_REMOTE=$(git config --get --default "$(git remote | head -n1)" publish.remote)

--- a/.sh/publish-component.sh
+++ b/.sh/publish-component.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+
+SCRIPT=$(basename "$0")
+PROJECT_ROOT=$(realpath "$(dirname "$0")"/..)
+COMPONENT_NAME=$1
+COMPONENT_VERSION=$2
+
+#
+# Validate
+#
+
+COMPONENT_PATH=
+
+# NOTE: git-subtree-split will fail on absolute paths, so COMPONENT_PATH must
+# be relativw ro PROJECT_ROOT
+test ! -d "$PROJECT_ROOT/$COMPONENT_NAME"             || COMPONENT_PATH=$COMPONENT_NAME
+test ! -d "$PROJECT_ROOT/deployments/$COMPONENT_NAME" || COMPONENT_PATH=deployments/$COMPONENT_NAME
+test "$PUBLISH_REMOTE"                                || PUBLISH_REMOTE=$(git config --get --default "$(git remote | head -n1)" publish.remote)
+
+if ! [[ $COMPONENT_PATH ]]; then
+  printf '%s: fatal: component not found: %s\n' "$SCRIPT" "$COMPONENT_NAME" >&2
+  exit 1
+fi
+
+if ! [[ $COMPONENT_VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+  printf '%s: fatal: invalid version specifier: %s\n' "$SCRIPT" "$COMPONENT_VERSION"
+  exit 1
+fi
+
+if ! [[ $PUBLISH_REMOTE ]]; then
+  printf '%s: fatal: no remote found. Configure one or set PUBLISH_REMOTE.\n' >&2
+  exit 1
+fi
+
+#
+# Publish
+#
+
+PUBLISH_REV=$(git subtree split -P "$COMPONENT_PATH")
+PUBLISH_TAG=$COMPONENT_NAME/$COMPONENT_VERSION
+LAST_RELEASE=$(git describe --abbrev=0 --always "$PUBLISH_REV")
+
+if [[ $LAST_RELEASE =~ [a-f0-9]{40} ]]; then
+  max_distance=0
+  for root_rev in $(git rev-list --max-parents=0 "$PUBLISH_REV"); do
+    this_distance=$(git rev-list --count "$root_rev".."$PUBLISH_REV")
+    if [[ $this_distance -gt $max_distance ]]; then
+      max_distance=$this_distance
+      LAST_RELEASE=$root_rev
+    fi
+  done
+fi
+
+printf '%s: info: release base: %s\n' "$SCRIPT" "$LAST_RELEASE"
+
+git tag -m "$(git shortlog "$LAST_RELEASE".."$PUBLISH_REV")" "$PUBLISH_TAG" "$PUBLISH_REV"
+git push "$PUBLISH_REMOTE" "$PUBLISH_TAG"


### PR DESCRIPTION
This change implements a workflow for publishing independently versioned infrastructure components. The workflow is as follows:

1. Perform changes on a topic branch prefixed with `releases/` which is named after a component (e.g., `releases/procedures/terraform/v1.0.0`, `releases/terraform/data-infra/v1.0.0`).
2. Merge the topic branch into `main` via the typical PR/review process
3. Observe the creation of the tag (e.g., `procedures/terraform/v1.0.0`, `terraform/data-infra/v1.0.0`) which points to a subtree containing only the named component