### PR TITLE
feat: add metabase chart

### DIFF
--- a/charts/metabase/.helmignore
+++ b/charts/metabase/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/metabase/Chart.yaml
+++ b/charts/metabase/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: metabase
+description: A Helm chart to deploy a metabase stack
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/metabase/templates/_helpers.tpl
+++ b/charts/metabase/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "metabase.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "metabase.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "metabase.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "metabase.labels" -}}
+helm.sh/chart: {{ include "metabase.chart" . }}
+{{ include "metabase.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "metabase.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "metabase.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "metabase.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "metabase.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/metabase/templates/database.yaml
+++ b/charts/metabase/templates/database.yaml
@@ -1,0 +1,142 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: database
+  namespace: {{ .Release.Namespace }}
+  labels:
+    name: database
+spec:
+  replicas: {{ .Values.workloads.database.replicas }}
+  selector:
+    matchLabels:
+      name: database
+  serviceName: database
+  template:
+    metadata:
+      labels:
+        name: database
+      {{- with .Values.workloads.database.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+    {{- with .Values.images.database.imagePullSecrets }}
+      imagePullSecrets:
+      {{ toYaml . | nindent 6 }}
+    {{- end }}
+      containers:
+
+      - name: database
+        image: {{ .Values.images.database.src }}
+        {{- if .Values.configs.database }}
+        envFrom:
+        - configMapRef:
+            name: database-config
+        {{- end }}
+        ports:
+        - containerPort: {{ .Values.workloads.database.port }}
+          name: postgresql
+        {{- if .Values.volumes.database }}
+        volumeMounts:
+          {{- if .Values.volumes.database.data }}
+          - name: data
+            mountPath: /var/lib/postgresql/data
+            subPath: postgresql-data
+          {{- end }}
+        {{- end }}
+        readinessProbe:
+          tcpSocket:
+            port: {{ .Values.workloads.database.port }}
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: {{ .Values.workloads.database.port }}
+          initialDelaySeconds: 15
+          periodSeconds: 20
+
+      {{- if .Values.workloads.database.useExporter }}
+      - name: exporter
+        image: {{ .Values.images.databaseExporter.src }}
+        env:
+          - name: DATA_SOURCE_URI
+            value: postgresql://localhost:{{ .Values.workloads.database.port }}
+          - name: DATA_SOURCE_USER
+            valueFrom:
+              configMapKeyRef:
+                key: POSTGRES_USER
+                name: database-config
+          - name: DATA_SOURCE_PASS
+            valueFrom:
+              configMapKeyRef:
+                key: POSTGRES_PASSWORD
+                name: database-config
+
+      {{- end }}
+      {{- with .Values.workloads.database.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.workloads.database.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.workloads.database.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+  {{- if .Values.volumes.database }}
+  volumeClaimTemplates:
+    {{- if .Values.volumes.database.data }}
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- if .Values.volumes.database.data.storageClassName }}
+        storageClassName: {{ .Values.volumes.database.data.storageClassName }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.volumes.database.data.size }}
+    {{- end }}
+  {{- end }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: database
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    name: database
+  type: {{ .Values.services.database.type }}
+  ports:
+  - name: postgresql
+    port: {{ .Values.services.database.port }}
+    targetPort: {{ .Values.workloads.database.port }}
+{{- if .Values.configs.database }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: database-config
+  namespace: {{ .Release.Namespace }}
+data:
+  {{- toYaml .Values.configs.database | nindent 2 }}
+{{- end }}
+{{- if .Values.configs.inputStreamer }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: input-streamer-eventhub
+  namespace: {{ .Release.Namespace }}
+data:
+  {{- toYaml .Values.configs.inputStreamer | nindent 2 }}
+{{- end }}

--- a/charts/metabase/templates/ingress.yaml
+++ b/charts/metabase/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "metabase.fullname" . -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "metabase.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: metabase
+              servicePort: {{ $.Values.services.metabase.port }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/charts/metabase/templates/metabase.yaml
+++ b/charts/metabase/templates/metabase.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metabase
+  namespace: {{ .Release.Namespace }}
+  labels:
+    name: metabase
+spec:
+  replicas: {{ .Values.workloads.metabase.replicas }}
+  selector:
+    matchLabels:
+      name: metabase
+  template:
+    metadata:
+      labels:
+        name: metabase
+    spec:
+    {{- with .Values.images.metabase.imagePullSecrets }}
+      imagePullSecrets:
+      {{ toYaml . | nindent 6 }}
+    {{- end }}
+      containers:
+        - name: metabase
+          image: {{ .Values.images.metabase.src }}
+          envFrom:
+            - configMapRef:
+                name: metabase-config
+          ports:
+          - containerPort: {{ .Values.workloads.metabase.port }}
+            name: metabase
+          startupProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.workloads.metabase.port }}
+            periodSeconds: 10
+            failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.workloads.metabase.port }}
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.workloads.metabase.port }}
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+            periodSeconds: 10
+            failureThreshold: 3
+
+      {{- with .Values.workloads.metabase.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.workloads.metabase.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      {{- with .Values.workloads.metabase.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metabase
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    name: metabase
+  type: {{ .Values.services.metabase.type }}
+  ports:
+    - name: metabase-http
+      port: {{ .Values.services.metabase.port }}
+      targetPort: {{ .Values.workloads.metabase.port }}
+{{- if .Values.configs.metabase }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metabase-config
+  namespace: {{ .Release.Namespace }}
+data:
+  {{- /* select first hostname from the ingress hosts list (if it exists; empty string otherwise) */}}
+  {{- /* to use as the default value of the MB_SITE_URL environment variable                      */}}
+  {{- $defaultHost := get (index (default (list (dict "host" "")) .Values.ingress.hosts) 0) "host" }}
+  {{- $emptyDict := dict }}
+  {{- $siteUrlDict := dict "MB_SITE_URL" (print "https://" $defaultHost) }}
+  {{- ne $defaultHost "" | ternary $siteUrlDict $emptyDict | merge .Values.configs.metabase | toYaml | nindent 2 }}
+{{- end }}

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -1,0 +1,61 @@
+# Default values for metabase.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+images:
+  database:
+    src: postgres:13.5
+    imagePullSecrets:
+    - name: regcred
+  metabase:
+    src: metabase/metabase:v0.38.2
+  databaseExporter:
+    src: quay.io/prometheuscommunity/postgres-exporter:0.9.0
+
+workloads:
+  database:
+    useExporter: true
+    replicas: 1
+    port: 5432
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/port: '9187'
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+  metabase:
+    replicas: 1
+    port: 3000
+    podAnnotations: {}
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+
+services:
+  database:
+    type: ClusterIP
+    port: 5432
+  metabase:
+    type: ClusterIP
+    port: 3000
+
+configs:
+  database:
+    POSTGRES_DB: metabase
+    POSTGRES_USER: admin
+    POSTGRES_PASSWORD: admin
+  metabase:
+    MB_DB_TYPE: postgres
+    MB_DB_DBNAME: metabase
+    MB_DB_PORT: "5432"
+    MB_DB_USER: admin
+    MB_DB_PASS: admin
+    MB_DB_HOST: database
+
+ingress:
+  enabled: false
+
+volumes:
+  database:
+    data:
+      size: 10Gi

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -4,13 +4,13 @@
 
 images:
   database:
-    src: postgres:13.5
+    src: postgres:13
     imagePullSecrets:
     - name: regcred
   metabase:
-    src: metabase/metabase:v0.45.1
+    src: metabase/metabase:latest
   databaseExporter:
-    src: quay.io/prometheuscommunity/postgres-exporter:0.9.0
+    src: quay.io/prometheuscommunity/postgres-exporter:latest
 
 workloads:
   database:

--- a/charts/metabase/values.yaml
+++ b/charts/metabase/values.yaml
@@ -8,7 +8,7 @@ images:
     imagePullSecrets:
     - name: regcred
   metabase:
-    src: metabase/metabase:v0.38.2
+    src: metabase/metabase:v0.45.1
   databaseExporter:
     src: quay.io/prometheuscommunity/postgres-exporter:0.9.0
 


### PR DESCRIPTION
Extracted from https://github.com/cal-itp/data-infra/tree/main/kubernetes/apps/charts/metabase

I used a temporary holorepo to compare the rendered+normalized output against that for https://github.com/urbanSpatial/LetsPlanOrg/tree/main/helm-chart and found no material improvements missing—they were essentially identical outside naming/labeling and the addition of the prom exporter in data-infra