### PR TITLE
feat(github-actions/k8s-prepare): add action

### DIFF
--- a/github-actions/k8s-prepare/.env.example
+++ b/github-actions/k8s-prepare/.env.example
@@ -1,0 +1,4 @@
+GITHUB_TOKEN=PASTE_YOUR_TOKEN
+GITHUB_REPOSITORY=exampleorg/exampleproject
+BRANCH_DEPLOY=deploys/k8s-manifests
+BRANCH_RELEASE=releases/k8s-manifests

--- a/github-actions/k8s-prepare/README.md
+++ b/github-actions/k8s-prepare/README.md
@@ -1,0 +1,31 @@
+# GitHub Action: k8s-prepare
+
+## Development
+
+This action encapsulates most of its complexity in a standalone Bash script that accepts environment variables, making it easy to test locally with the help of a `.env` file you can point at a test repository.
+
+1. Create `.env` from the template:
+
+    ```bash
+    cp .env.example .env
+    ```
+
+2. Paste a GitHub token and tailor repository/branches to your test target.
+
+3. Save this directory's complete path in a shell variable:
+
+    ```bash
+    export GITHUB_ACTION_PATH="$(pwd)"
+    ```
+
+4. Change into your test target's local git clone:
+
+    ```bash
+    cd ~/Repositories/test-repo
+    ```
+
+5. Run bash script with `.env` applied to emulate GitHub Actions context:
+
+    ```bash
+    eval $(< "${GITHUB_ACTION_PATH}/.env") "${GITHUB_ACTION_PATH}/pull-request.sh"
+    ```

--- a/github-actions/k8s-prepare/pull-request.sh
+++ b/github-actions/k8s-prepare/pull-request.sh
@@ -32,11 +32,13 @@ fi
 echo
 echo "Looking for existing open PR for branch ${BRANCH_RELEASE}..."
 _existing_pr_number=$(
-    gh pr view "${BRANCH_RELEASE}" \
-    --json number,state \
-    --template '{{.number}}{{"\t"}}{{.state}}' \
-    | grep OPEN \
-    | awk '{print $1}'
+    gh pr list \
+        --head "${BRANCH_RELEASE}" \
+        --base "${BRANCH_DEPLOY}" \
+        --state open \
+        --limit 1 \
+        --json number \
+        --jq '.[0].number'
 )
 
 if [ -n "${_existing_pr_number}" ]; then

--- a/github-actions/k8s-prepare/pull-request.sh
+++ b/github-actions/k8s-prepare/pull-request.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+
+## build PR description body
+echo
+echo "Builing PR title+body content..."
+diff_size=$(du -k '/tmp/kube.diff' | cut -f1)
+pr_head_describe="$(git describe --always --tag)"
+
+pr_title="Deploy ${BRANCH_RELEASE} ${pr_head_describe}"
+pr_body="$(cat <<EOF
+\`kubectl diff\` reports that applying ${pr_head_describe} will change:
+
+\`\`\`diff
+$(if (( diff_size > 50000)); then echo 'diff too big; review locally'; else cat /tmp/kube.diff; fi)
+\`\`\`
+EOF
+)"
+
+
+## generate initial commit for base if needed
+if ! git ls-remote --exit-code --heads origin "${BRANCH_DEPLOY}"; then
+    echo
+    echo "Existing branch ${BRANCH_DEPLOY} not found, generating initial commit..."
+    git fetch origin --unshallow
+    _first_projected_commit=$(git rev-list --max-parents=0 --first-parent HEAD)
+    git push origin "${_first_projected_commit}:refs/heads/${BRANCH_DEPLOY}"
+fi
+
+
+## check for existing PR
+echo
+echo "Looking for existing open PR for branch ${BRANCH_RELEASE}..."
+_existing_pr_number=$(
+    gh pr view "${BRANCH_RELEASE}" \
+    --json number,state \
+    --template '{{.number}}{{"\t"}}{{.state}}' \
+    | grep OPEN \
+    | awk '{print $1}'
+)
+
+if [ -n "${_existing_pr_number}" ]; then
+    echo
+    echo "Found existing PR #${_existing_pr_number}, updating description..."
+    pr_url=$(
+        gh api "/repos/${GITHUB_REPOSITORY}/pulls/${_existing_pr_number}" \
+            --field title="${pr_title}" \
+            --field body="${pr_body}" \
+            --jq '.url'
+    )
+    echo "Updated PR: ${pr_url}"
+else
+    echo
+    echo "Opening PR..."
+    pr_url=$(
+        gh pr create \
+            --base "${BRANCH_DEPLOY}" \
+            --head "${BRANCH_RELEASE}" \
+            --title "${pr_title}" \
+            --body "${pr_body}"
+    )
+    pr_number="${pr_url##*/}"
+    echo "Opened PR #${pr_number}"
+fi


### PR DESCRIPTION
This composite action is being ported from `cluster-template/github-workflows`:

- [X] Scaffold out composite action folder
- [X] Use it to test fixed release and deploy a final `cluster-template` release including it embedded
- [ ] Complete composite action and make first release
- [ ] Bump `cluster-template` to a new major version and remove embedded GitHub actions and -github alt builds
- [ ] Add stub actions to `cluster-repo-template` that invoke latest composite action
- [ ] Document `cluster-template` upgrade notes