### PR TITLE
fix(github-actions/release-prepare): handle duplicate changelog comments

### DIFF
--- a/github-actions/release-prepare/pull-request.sh
+++ b/github-actions/release-prepare/pull-request.sh
@@ -39,7 +39,22 @@ pr_number=$(
 
 if [ -n "${pr_number}" ]; then
     echo "Found existing PR #${pr_number}, looking for existing comment..."
-    existing_comment_id=$(gh api "/repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments" --jq '.[] | select(.body | startswith("## Changelog\n\n")) | .id')
+
+    # If two release-prepare runs raced (e.g. two PRs merged within seconds), each
+    # may have created its own changelog comment. Keep the oldest match and delete
+    # any extras so we have exactly one comment to update from here on.
+    existing_comment_id=""
+    while IFS= read -r comment_id; do
+        if [ -z "${existing_comment_id}" ]; then
+            existing_comment_id="${comment_id}"
+        else
+            echo "Deleting duplicate changelog comment #${comment_id}"
+            gh api -X DELETE "/repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}"
+        fi
+    done < <(
+        gh api "/repos/${GITHUB_REPOSITORY}/issues/${pr_number}/comments" \
+            --jq '[.[] | select(.body | startswith("## Changelog\n\n"))] | sort_by(.created_at) | .[].id'
+    )
 else
     echo "Opening PR..."
     pr_url=$(


### PR DESCRIPTION
When two release-prepare runs fire close together (e.g. two PRs merged within seconds), each can race past the existing-comment lookup and create its own `## Changelog` comment on the release PR. The next run's lookup then returns multiple ids joined by newlines, which get substituted straight into the update URL:

```
parse "/repos/.../issues/comments/<id1>\n<id2>": net/url: invalid control character in URL
##[error]Process completed with exit code 1.
```

After that, every subsequent release-prepare run on the branch fails until the duplicate is manually deleted.

Sort matching comments by `created_at`, keep the oldest as the update target, and delete the rest — self-healing on the next run after the race.

A composite action can't define `concurrency:`, so the race itself isn't preventable from here; this just makes the script tolerant of it.

Observed on [JarvusInnovations/git-client#57](https://github.com/JarvusInnovations/git-client/pull/57) after merging git-client#55 and #56 within ~1 second of each other ([failing run](https://github.com/JarvusInnovations/git-client/actions/runs/26047958835/job/76577175701)).