### PR TITLE
feat(github-actions/release-prepare): add release-tag-match to isolate one tag track

### DIFF
--- a/github-actions/release-prepare/.env.example
+++ b/github-actions/release-prepare/.env.example
@@ -2,3 +2,6 @@ GITHUB_TOKEN=PASTE_YOUR_TOKEN
 GITHUB_REPOSITORY=exampleorg/exampleproject
 RELEASE_BRANCH=main
 GITHUB_REF_NAME=develop
+# Optional: restrict version computation to one tag track (git describe --match glob).
+# Set when the repo has multiple prefix-namespaced tag tracks, e.g. RELEASE_TAG_MATCH='v[0-9]*'
+RELEASE_TAG_MATCH=

--- a/github-actions/release-prepare/README.md
+++ b/github-actions/release-prepare/README.md
@@ -1,5 +1,29 @@
 # GitHub Action: release-prepare
 
+Opens/refreshes the `Release: vX.Y.Z` pull request from the working branch into the release branch, computing the next version as **last release tag + patch bump** and posting a changelog comment.
+
+## Inputs
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `github-token` | yes | — | Token used to open/update the PR and read commit/PR metadata. |
+| `release-branch` | no | `main` | Branch releases merge into (the base of the Release PR). |
+| `release-tag-match` | no | `''` (all tags) | Glob passed to `git describe --match`, restricting which tags are considered when computing the next version. |
+
+### `release-tag-match` — isolating one tag track
+
+The next version is derived from the most recent tag reachable on the release branch. When a repo publishes **multiple artifacts on separate prefix-namespaced tag tracks that share one git tag space** — e.g. a JS package on `v*` alongside native-binding tracks like `holo-tree-v*` / `foo-v*` — a tag from *another* track can be the topologically nearest one and poison the computed title (bumping `holo-tree-v0.5.0` → `holo-tree-v0.5.1` for what should be a `v*` release). Set `release-tag-match` to this release's own track so only its tags count:
+
+```yaml
+- uses: JarvusInnovations/infra-components@channels/github-actions/release-prepare/latest
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    release-branch: master
+    release-tag-match: 'v[0-9]*'   # the JS `v*` track, not the `*-v*` binding tracks
+```
+
+A no-match (a brand-new track) falls through to the `v0.1.0` default. Omit the input to consider all tags (prior behavior, unchanged).
+
 ## Development
 
 This action encapsulates most of its complexity in a standalone Bash script that accepts environment variables, making it easy to test locally with the help of a `.env` file you can point at a test repository.

--- a/github-actions/release-prepare/action.yml
+++ b/github-actions/release-prepare/action.yml
@@ -8,6 +8,16 @@ inputs:
     description: 'Name of branch to merge releases into'
     required: false
     default: 'main'
+  release-tag-match:
+    description: >-
+      Optional glob (passed to `git describe --match`) limiting which tags are
+      considered when computing the next release version. Set this when the repo
+      publishes multiple artifacts on separate prefix-namespaced tag tracks that
+      share one git tag space (e.g. a JS package on `v*` alongside native-binding
+      tracks like `foo-v*`), so a tag from another track cannot poison the
+      computed title. Example: `v[0-9]*`. Default: all tags considered.
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -22,4 +32,5 @@ runs:
     run: ${{ github.action_path }}/pull-request.sh
     env:
       RELEASE_BRANCH: ${{ inputs.release-branch }}
+      RELEASE_TAG_MATCH: ${{ inputs.release-tag-match }}
       GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/github-actions/release-prepare/pull-request.sh
+++ b/github-actions/release-prepare/pull-request.sh
@@ -2,8 +2,18 @@
 
 
 # get latest release tag
+# When RELEASE_TAG_MATCH is set, only tags matching that glob are considered, so
+# a repo with multiple prefix-namespaced tag tracks sharing one git tag space
+# (e.g. `v*` for a JS package plus `foo-v*` for a native binding) computes the
+# next version from its own track rather than whatever tag is topologically
+# nearest. A no-match (a brand-new track) falls through to the v0.1.0 default.
 echo "Looking for last tag..."
-latest_release=$(git describe --tags --abbrev=0 "origin/${RELEASE_BRANCH}")
+if [ -n "${RELEASE_TAG_MATCH}" ]; then
+    echo "Restricting to tags matching: ${RELEASE_TAG_MATCH}"
+    latest_release=$(git describe --tags --abbrev=0 --match "${RELEASE_TAG_MATCH}" "origin/${RELEASE_BRANCH}" 2>/dev/null || true)
+else
+    latest_release=$(git describe --tags --abbrev=0 "origin/${RELEASE_BRANCH}" 2>/dev/null || true)
+fi
 
 
 # generate next patch release tag


### PR DESCRIPTION
## The bug

`release-prepare` computes the next version as `git describe --tags --abbrev=0 <release-branch>` + patch bump. `git describe` is **namespace-blind** — it returns whatever tag is topologically nearest. In a repo with multiple prefix-namespaced tag tracks sharing one git tag space (a JS package on `v*` plus native-binding tracks like `holo-tree-v*` / `holo-projector-v*`), a tag from *another* track poisons the computed title.

Live example: hologit's develop→master Release PR was titled **`Release: holo-tree-v0.5.1`** — it bumped the nearest tag (`holo-tree-v0.5.0`) instead of the JS track's `v0.51.0`.

## The fix

An opt-in `release-tag-match` input (glob → `git describe --match`) restricting version computation to one track. Proven against real tags:

```
hologit  buggy → holo-tree-v0.5.1     fixed (--match 'v[0-9]*') → v0.51.1
gitsheets                              fixed (--match 'v[0-9]*') → v2.4.0
```

- **Backward compatible**: default `''` = all tags (prior behavior). Non-`v` tag schemes (including infra-components' own `<component>/rN` releases) are unaffected — you only opt in per consumer.
- A no-match (brand-new track) falls through to the `v0.1.0` default.
- Documented in the component README (with the multi-track rationale) and `.env.example`.

Consumers that need it (hologit, gitsheets) will set `release-tag-match: 'v[0-9]*'` in their `release-prepare.yml` once this ships on the `channels/github-actions/release-prepare/latest` channel.